### PR TITLE
Update data dir mechanism

### DIFF
--- a/docs/_docs/core.md
+++ b/docs/_docs/core.md
@@ -18,7 +18,7 @@ Then, you can start using the functions in this module.
 ## `download_dataverse`
 
 ```python
-sdd.download_dataverse(api_token, server_url="https://borealisdata.ca", persistent_id="doi:10.5683/SP3/NR0BMY", filename="task_data.zip", data_dir=None, overwrite=False)
+sdd.download_dataverse(api_token, server_url="https://borealisdata.ca", persistent_id="doi:10.5683/SP3/NR0BMY", filename="task_data.zip", data_dir=None, overwrite=False, bundle_name="dataverse_files.zip", remove_bundle=False)
 ```
 
 ### Description
@@ -39,7 +39,8 @@ from the account that has been granted access to the file.
 | `filename` | `str` | `"task_data.zip"` | The name of the file to download. By default, this is the name of the file in the StatCan Dialogue Dataset. |
 | `data_dir` | `str or Path` | `None` | The directory to download the file to. By default, this is the directory returned by `utils.get_data_dir()`. If the directory does not exist, it will be created. |
 | `overwrite` | `bool` | `False` | Whether to overwrite the file if it already exists. By default, this is False, which means that the file will not be downloaded if it already exists. |
-
+| `bundle_name` | `str` | `"dataverse_files.zip"` | The name of the bundle file that contains the file to download. By default, this is the default name used by Dataverse. Note that it is indeed possible that it contains a zip file (so a zip in a zip), which is the case by default (task_data.zip  is contained in dataverse_files.zip). You generally don't need to change this nor  the `filename` above. |
+| `remove_bundle` | `bool` | `False` | Whether to remove the bundle file after extracting the file. |
 
 ### Note
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,9 @@ version = {}
 with open("statcan_dialogue_dataset/version.py") as fp:
     exec(fp.read(), version)
 
+with open("README.md") as fp:
+    long_description = fp.read()
+
 setup(
     name="statcan-dialogue-dataset",
     version=version["__version__"],
@@ -11,6 +14,7 @@ setup(
     author_email="statcan.dialogue.dataset@mila.quebec",
     url="https://github.com/McGill-NLP/statcan-dialogue-dataset",
     description="The Statcan Dialogue Dataset",
+    long_description=long_description,
     packages=find_packages(include=["statcan_dialogue_dataset*"]),
     package_data={
         "statcan_dialogue_dataset": ["_data/*.json", "_data/members.zip"]

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as fp:
 setup(
     name="statcan-dialogue-dataset",
     version=version["__version__"],
-    author="Xing Han Lu, Siva Reddy, Harm De Vries",
+    author="Xing Han Lu, Siva Reddy, Harm de Vries",
     author_email="statcan.dialogue.dataset@mila.quebec",
     url="https://github.com/McGill-NLP/statcan-dialogue-dataset",
     description="The Statcan Dialogue Dataset",
@@ -25,4 +25,12 @@ setup(
     extras_require={
         "dev": ["black", "wheel"]
     },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.7",
+    # Cast long description to markdown
+    long_description_content_type="text/markdown",
 )

--- a/statcan_dialogue_dataset/__init__.py
+++ b/statcan_dialogue_dataset/__init__.py
@@ -62,11 +62,7 @@ def download_dataverse(
     ----
     Once this is downloaded, you can load the task data using the `extract_task_data_zip` function.
     """
-    if data_dir is None:
-        data_dir = utils.get_data_dir()
-    else:
-        data_dir = Path(data_dir)
-        data_dir.mkdir(parents=True, exist_ok=True)
+    utils.infer_and_create_dir(data_dir, utils.get_data_dir())
     
     if (data_dir / filename).exists() and not overwrite:
         print(f"File {filename} already exists in {data_dir}. Skipping download.")
@@ -129,11 +125,7 @@ def download_huggingface(
     ----
     Once this is downloaded, you can load the task data using the `extract_task_data_zip` function.
     """
-    if data_dir is None:
-        data_dir = utils.get_data_dir()
-    else:
-        data_dir = Path(data_dir)
-        data_dir.mkdir(parents=True, exist_ok=True)
+    utils.infer_and_create_dir(data_dir, utils.get_data_dir())
     
     if (data_dir / filename).exists() and not overwrite:
         print(f"File {filename} already exists in {data_dir}. Skipping download.")
@@ -176,11 +168,7 @@ def download_full_tables(
     Path
         The path to the downloaded tables.
     """
-    if data_dir is None:
-        data_dir = utils.get_data_dir()
-    else:
-        data_dir = Path(data_dir)
-        data_dir.mkdir(parents=True, exist_ok=True)
+    utils.infer_and_create_dir(data_dir, utils.get_data_dir())
 
     if lang not in ["en", "fr"]:
         raise ValueError(f"lang must be 'en' or 'fr', not '{lang}'")

--- a/statcan_dialogue_dataset/__init__.py
+++ b/statcan_dialogue_dataset/__init__.py
@@ -22,6 +22,8 @@ def download_dataverse(
     filename="task_data.zip",
     data_dir=None,
     overwrite=False,
+    bundle_name="dataverse_files.zip",
+    remove_bundle=False,
 ):
     """
     Download a file from a Dataverse repository. By default, this downloads the
@@ -58,26 +60,45 @@ def download_dataverse(
         Whether to overwrite the file if it already exists. By default, this is False,
         which means that the file will not be downloaded if it already exists.
 
+    bundle_name : str, default "dataverse_files.zip"
+        The name of the bundle file that contains the file to download. By default,
+        this is the default name used by Dataverse. Note that it is indeed possible that it
+        contains a zip file (so a zip in a zip), which is the case by default (task_data.zip 
+        is contained in dataverse_files.zip). You generally don't need to change this nor 
+        the `filename` above.
+    
+    remove_bundle : bool, default False
+        Whether to remove the bundle file after extracting the file.
+    
     Note
     ----
     Once this is downloaded, you can load the task data using the `extract_task_data_zip` function.
     """
-    utils.infer_and_create_dir(data_dir, utils.get_data_dir())
+    data_dir = utils.infer_and_create_dir(data_dir, utils.get_data_dir())
     
     if (data_dir / filename).exists() and not overwrite:
         print(f"File {filename} already exists in {data_dir}. Skipping download.")
         return
+    elif (data_dir / bundle_name).exists() and not overwrite:
+        print(f"File {bundle_name} already exists in {data_dir}. Skipping download.")
+    else:
+        url = f"{server_url}/api/access/dataset/:persistentId?persistentId={persistent_id}"
 
-    url = f"{server_url}/api/access/dataset/:persistentId?persistentId={persistent_id}"
+        # Need to pass the API token in the header
+        headers = {"X-Dataverse-key": api_token}
 
-    # Need to pass the API token in the header
-    headers = {"X-Dataverse-key": api_token}
+        # Make the request with urllib
+        with urllib.request.urlopen(urllib.request.Request(url, headers=headers)) as response:
+            with open(data_dir / bundle_name, "wb") as f:
+                f.write(response.read())
 
-    # Make the with urllib
-    with urllib.request.urlopen(urllib.request.Request(url, headers=headers)) as response:
-        with open(data_dir / filename, "wb") as f:
-            f.write(response.read())
+    # Extract the file from the bundle
+    with zipfile.ZipFile(data_dir / bundle_name, "r") as zip_ref:
+        zip_ref.extract(filename, data_dir)
 
+    if remove_bundle:
+        os.remove(data_dir / bundle_name)
+    
     return data_dir / filename
 
 def download_huggingface(
@@ -125,7 +146,7 @@ def download_huggingface(
     ----
     Once this is downloaded, you can load the task data using the `extract_task_data_zip` function.
     """
-    utils.infer_and_create_dir(data_dir, utils.get_data_dir())
+    data_dir = utils.infer_and_create_dir(data_dir, utils.get_data_dir())
     
     if (data_dir / filename).exists() and not overwrite:
         print(f"File {filename} already exists in {data_dir}. Skipping download.")
@@ -168,7 +189,7 @@ def download_full_tables(
     Path
         The path to the downloaded tables.
     """
-    utils.infer_and_create_dir(data_dir, utils.get_data_dir())
+    data_dir = utils.infer_and_create_dir(data_dir, utils.get_data_dir())
 
     if lang not in ["en", "fr"]:
         raise ValueError(f"lang must be 'en' or 'fr', not '{lang}'")
@@ -249,7 +270,7 @@ def extract_task_data_zip(filename="task_data.zip", data_dir=None, load_dir=None
 
     # Extract file and save it to the data directory
     with zipfile.ZipFile(path, "r") as zip_ref:
-        zip_ref.extractall(data_dir)
+        zip_ref.extractall(str(data_dir))
 
     # Remove the ZIP file
     if remove_zip:
@@ -312,7 +333,7 @@ def extract_full_tables(data_dir=None, remove_zip=False, lang="en"):
         data_dir = Path(data_dir)
 
     with zipfile.ZipFile(data_dir / f"tables-{lang}.zip", "r") as zip_ref:
-        zip_ref.extractall(data_dir / f"tables-{lang}")
+        zip_ref.extractall(str(data_dir / f"tables-{lang}"))
 
     if remove_zip:
         os.remove(data_dir / f"tables-{lang}.zip")

--- a/statcan_dialogue_dataset/utils.py
+++ b/statcan_dialogue_dataset/utils.py
@@ -35,3 +35,15 @@ def get_temp_dir():
     """
     return Path(os.getenv("STATCAN_TEMP_DIR", get_data_dir())) / "temp"
 
+def infer_and_create_dir(dir_name: str, default_dir: Path):
+    """
+    Automatically infers the directory from the given path. If dir_name is None, returns the default data directory.
+    Otherwise, cast dirname to a Path object, create the directory, and return it.
+    """
+    if dir_name is None:
+        dir_name = default_dir
+    
+    path = Path(dir_name)
+    path.mkdir(parents=True, exist_ok=True)
+    
+    return path

--- a/statcan_dialogue_dataset/version.py
+++ b/statcan_dialogue_dataset/version.py
@@ -1,1 +1,1 @@
-__version__ = '0.0.1.dev0'
+__version__ = '0.2.0.dev0'


### PR DESCRIPTION
Changes:
* Create directory automatically when downloading even when data_dir is not specified
* Add readme to pypi.org

Fix:
* Correct issue when downloading from new version of dataset in dataverse

Release candidate: https://github.com/McGill-NLP/statcan-dialogue-dataset/releases/tag/0.2.0.dev1

